### PR TITLE
Fix HAVE_MPI_H detection and a sweep of audit findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Molpro utilities library
 =================
 
 This library consists of various utilities needed for Molpro and its libraries:
- - the header ``molpro/iostream.h`` which contains definitions of ``molpro::cout`` and ``molpro::stderr`` which should be used in any library used in Molpro instead of ``std::cout`` and ``std::cerr``.
+ - the header ``molpro/iostream.h`` which contains definitions of ``molpro::cout`` and ``molpro::cerr`` which should be used in any library used in Molpro instead of ``std::cout`` and ``std::cerr``.
 By default, they are simply an alias for the `std::` streams, but
 clients of the library can then, if desired, redirect by defining `EXTERN_OSTREAM_COUT` as the desired `extern std::ostream&`.
    

--- a/src/molpro/CMakeLists.txt
+++ b/src/molpro/CMakeLists.txt
@@ -3,7 +3,7 @@ LibraryManager_Append(${PROJECT_NAME}
         PUBLIC_HEADER iostream.h mpi.h cblas.h lapacke.h Options.h memory.h bytestreamC.h
         SOURCES Options.cpp memoryC.cpp bytestreamC.cpp
         )
-target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_14)
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_EXTENSIONS OFF)
 if (FORTRAN)
     set(MOLPRO_MEMORY_FORTRAN ON)

--- a/src/molpro/bytestreamC.cpp
+++ b/src/molpro/bytestreamC.cpp
@@ -2,6 +2,7 @@
 #include <cstring>
 #include <cassert>
 #include <iostream>
+#include <stdexcept>
 //#include <molpro/iostream.h>
 
 bool debug_bytestream = false;
@@ -166,9 +167,8 @@ void bytestream::put_metadata(size_t length, enum datatypes datatype) {
     int tester = 1;
     bigend = (*(char*) &tester != 1);
   } // bigendian or littlendian
-  assert (not bigend);
-//  molpro::cout << "put_metadata pointer="<<pointer<<", datatype="<<datatype<<std::endl;memory_print_status();
-  if (bigend) return; // to keep compiler happy
+  if (bigend)
+    throw std::runtime_error("bytestream::put_metadata: big-endian hosts are not supported");
   (buffer)[pointer++] =
       datatype | (length > 2147483647 ? 0x20 : (length > 32767 ? 0xC0 : (length > 127 ? 0x40 : 0x80)));
   size_t l = (length > 2147483647 ? 8 : (length > 32767 ? 4 : (length > 127 ? 2 : 1)));

--- a/src/molpro/bytestreamC.cpp
+++ b/src/molpro/bytestreamC.cpp
@@ -14,13 +14,12 @@ bytestream::bytestream() {
   reset();
 }
 
-bytestream::bytestream(const char* buffer) {
+bytestream::bytestream(const char* src) {
   uint64_t length64;
-  std::memcpy(&length64, buffer, 8);
+  std::memcpy(&length64, src, 8);
   size_t length = length64;
-//  molpro::cout <<"bytestream constructor from buffer length "<<length<<std::endl;
-  this->buffer.resize(length);
-  if (length > 0) std::memcpy(this->buffer.data(), buffer, length);
+  buffer.resize(length);
+  if (length > 0) std::memcpy(buffer.data(), src, length);
   reset();
 }
 

--- a/src/molpro/bytestreamC.cpp
+++ b/src/molpro/bytestreamC.cpp
@@ -3,7 +3,7 @@
 #include <cassert>
 #include <iostream>
 #include <stdexcept>
-//#include <molpro/iostream.h>
+#include <molpro/iostream.h>
 
 bool debug_bytestream = false;
 using molpro::bytestream;
@@ -15,7 +15,7 @@ bytestream::bytestream() {
 }
 
 bytestream::bytestream(const char* buffer) {
-  int64_t length64;
+  uint64_t length64;
   std::memcpy(&length64, buffer, 8);
   size_t length = length64;
 //  molpro::cout <<"bytestream constructor from buffer length "<<length<<std::endl;

--- a/src/molpro/bytestreamC.cpp
+++ b/src/molpro/bytestreamC.cpp
@@ -20,7 +20,7 @@ bytestream::bytestream(const char* buffer) {
   size_t length = length64;
 //  molpro::cout <<"bytestream constructor from buffer length "<<length<<std::endl;
   this->buffer.resize(length);
-  for (size_t k = 0; k < length; k++) this->buffer[k] = buffer[k];
+  if (length > 0) std::memcpy(this->buffer.data(), buffer, length);
   reset();
 }
 

--- a/src/molpro/bytestreamC.h
+++ b/src/molpro/bytestreamC.h
@@ -150,8 +150,6 @@ class bytestream {
   void put_metadata(size_t length, enum datatypes datatype);
   std::vector<char> buffer;
   size_t pointer;
-public:
-  size_t position() { return pointer; }
 };
 }
 

--- a/src/molpro/bytestreamC.h
+++ b/src/molpro/bytestreamC.h
@@ -107,10 +107,11 @@ class bytestream {
   }
 
   template<class T>
-  void append(const std::vector<T> array) {
+  void append(const std::vector<T>& array) {
     std::vector<fint> o;
-    for (auto& i : array) o.push_back(i);
-    append(&o[0], o.size());
+    o.reserve(array.size());
+    for (const auto& i : array) o.push_back(i);
+    append(o.data(), o.size());
   }
 
   /*!

--- a/src/molpro/cblas.h
+++ b/src/molpro/cblas.h
@@ -5,7 +5,7 @@
  * @brief Non-forcing inclusion of cblas header file.
  * If successful, HAVE_CBLAS is defined.
  */
-#if __has_include(<mkl_lapacke.h>) && ! defined(NO_USE_MKL)
+#if __has_include(<mkl_cblas.h>) && ! defined(NO_USE_MKL)
 #include <mkl_cblas.h>
 #define HAVE_CBLAS
 #define HAVE_MKL

--- a/src/molpro/memory.h
+++ b/src/molpro/memory.h
@@ -538,7 +538,7 @@ class vector {
 
 /*!
  * \brief Resize the buffer.
- * \param n New length in bytes.
+ * \param n New number of elements.
  */
   void resize(size_t n) {
     m_stdvector.resize(n);
@@ -547,7 +547,7 @@ class vector {
 
 /*!
  * \brief Resize the buffer, and assign a value to any new elements if it grows.
- * \param n New length in bytes.
+ * \param n New number of elements.
  * \param val Value to assign to new elements.
  */
   void resize(size_t n, const T& val) {
@@ -600,26 +600,6 @@ std::ptrdiff_t operator-(const pointer_holder<T>& a,
 {
   return a.m_ptr - b.m_ptr;
 }
-
-template <typename T, typename _Alloc>
-typename vector<T, _Alloc>::Iterator operator+(const typename vector<T, _Alloc>::Iterator& a,
-                                               int increment)
-{
-  auto result = vector<T, _Alloc>::Iterator(a);
-  result += increment;
-  return result;
-}
-
-template <typename T, typename _Alloc>
-typename vector<T, _Alloc>::Iterator operator-(const typename vector<T, _Alloc>::Iterator& a,
-                                               int increment)
-{
-  auto result = vector<T, _Alloc>::Iterator(a);
-  result -= increment;
-  return result;
-}
-
-
 
 /*!
  * @brief A template for a container class like std::array<T> but with the following features.
@@ -717,8 +697,8 @@ class array {
  */
   array(std::initializer_list<T>
            il)
-      : m_allocator(), m_length(il.size()),
-        m_buffer(m_allocator.allocate(il.size())), m_owned(true) { std::copy(il.begin(), il.end(), begin()); }
+      : m_allocator(), m_length(il.size()), m_owned(true),
+        m_buffer(m_allocator.allocate(il.size())) { std::copy(il.begin(), il.end(), begin()); }
 
 /*!
  * \brief Construct an array of type T by attaching to an existing buffer.

--- a/src/molpro/memory.h
+++ b/src/molpro/memory.h
@@ -718,15 +718,15 @@ class array {
  * \param array Existing std::array of type T whose buffer will be used.
  */
   template<std::size_t N>
-  explicit array(std::array<T, N>& array)
-      : m_length(array.size()), m_owned(false), m_buffer(array.data()) {}
+  explicit array(std::array<T, N>& source)
+      : m_length(source.size()), m_owned(false), m_buffer(source.data()) {}
 
 /*!
  * \brief Construct an array of type T by attaching to an existing buffer.
- * \param array Existing std::vector of type T whose buffer will be used. Any subsequent external reallocation of array will cause chaos.
+ * \param source Existing std::vector of type T whose buffer will be used. Any subsequent external reallocation of source will cause chaos.
  */
-  explicit array(std::vector<T>& array)
-      : m_length(array.size()), m_owned(false), m_buffer(array.data()) {}
+  explicit array(std::vector<T>& source)
+      : m_length(source.size()), m_owned(false), m_buffer(source.data()) {}
 
 /*!
  * \brief array Copy constructor

--- a/src/molpro/memory.h
+++ b/src/molpro/memory.h
@@ -1,25 +1,21 @@
 #ifndef MOLPRO_MEMORY_H
 #define MOLPRO_MEMORY_H
+#include <algorithm>
+#include <array>
+#include <cassert> // assumed that NDEBUG is set properly for optimised compilation
+#include <climits>
 #include <cstddef>
 #include <cstdint>
-#include <sstream>
-#include <iostream>
-#include <limits>
-#include <string>
-#include <unordered_map>
-#include <new>
-#include <vector>
-#include <array>
-#include <stdexcept>
-#include <cassert> // assumed that NDEBUG is set properly for optimised compilation
+#include <initializer_list>
 #include <iostream>
 #include <iterator>
-#include <algorithm>
-#include <initializer_list>
-#ifdef __cplusplus
-#include <climits>
-#endif
 #include <limits>
+#include <new>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <vector>
 #include <molpro/memory/memory-config.h>
 
 #ifdef MOLPRO_MEMORY_FORTRAN
@@ -226,8 +222,8 @@ class allocator_ : public A {
                    ptr, std::forward<Args>(args)...);
   }
 
-  bool operator==(allocator_ const&) { return true; }
-  bool operator!=(allocator_ const& a) { return !operator==(a); }
+  bool operator==(allocator_ const&) const { return true; }
+  bool operator!=(allocator_ const& a) const { return !operator==(a); }
 };
 template<typename T>
 using allocator = allocator_<T, std::allocator<T> >;

--- a/src/molpro/memory.h
+++ b/src/molpro/memory.h
@@ -582,8 +582,10 @@ class vector {
 
   template<class... Args>
   iterator emplace(const_iterator pos, Args&& ... args) {
-    m_stdvector.emplace(pos, std::forward<Args>(args)...);
+    auto it = m_stdvector.emplace(m_stdvector.begin() + (&(*pos) - data()),
+                                  std::forward<Args>(args)...);
     m_buffer = m_stdvector.data();
+    return &(*it);
   }
 
 };
@@ -705,7 +707,9 @@ class array {
            first,
            InputIterator last
   )
-      : m_allocator(), m_length(last - first), m_buffer(m_allocator.allocate(last - first)), m_owned(true) {}
+      : m_allocator(), m_length(last - first), m_owned(true), m_buffer(m_allocator.allocate(last - first)) {
+    std::copy(first, last, begin());
+  }
 
 /*!
  * \brief Construct a vector of type T with managed storage.
@@ -764,11 +768,11 @@ class array {
   }
 
   T& operator[](size_t n) {
-    assert(m_length == 0 || (n <= m_length));
+    assert(n < m_length);
     return m_buffer[n];
   }
   const T& operator[](size_t n) const {
-    assert(m_length == 0 || (n <= m_length));
+    assert(n < m_length);
     return m_buffer[n];
   }
 /*!

--- a/src/molpro/memory.h
+++ b/src/molpro/memory.h
@@ -425,10 +425,14 @@ class vector {
  * \brief Exchange the content of the container by the content of x, which is another object of the same type.
  * \param x Another vector of the same type.
  */
-  void swap(vector<T, _Alloc>& x) { swap(*this, x); }
+  void swap(vector<T, _Alloc>& x) noexcept {
+    using std::swap;
+    swap(m_stdvector, x.m_stdvector);
+    swap(m_buffer, x.m_buffer);
+  }
 
-  friend void swap(vector<T, _Alloc>& a, vector<T, _Alloc>& b) {
-    std::swap(a.m_stdvector, b.m_stdvector);
+  friend void swap(vector<T, _Alloc>& a, vector<T, _Alloc>& b) noexcept {
+    a.swap(b);
   }
 
   template <bool IsConst>
@@ -851,12 +855,15 @@ class array {
  * \brief Exchange the content of the container by the content of x, which is another object of the same type.
  * \param x Another array of the same type.
  */
-  void swap(array<T>& x) { swap(*this, x); }
+  void swap(array<T>& x) noexcept {
+    using std::swap;
+    swap(m_buffer, x.m_buffer);
+    swap(m_length, x.m_length);
+    swap(m_owned, x.m_owned);
+  }
 
-  friend void swap(array<T>& a, array<T>& b) {
-    std::swap(a.m_buffer, b.m_buffer);
-    std::swap(a.m_length, b.m_length);
-    std::swap(a.m_owned, b.m_owned);
+  friend void swap(array<T>& a, array<T>& b) noexcept {
+    a.swap(b);
   }
 
   template <bool IsConst>

--- a/src/molpro/memory.h
+++ b/src/molpro/memory.h
@@ -348,8 +348,8 @@ class vector {
  */
   template<class InputIterator>
   void assign(InputIterator first, InputIterator last) {
-    if (last - first != m_stdvector.size()) resize(last - first);
-    std::copy(first, last, begin());
+    m_stdvector.assign(first, last);
+    m_buffer = m_stdvector.data();
   }
 /*!
  * \brief Assign new contents to the vector, replacing its current contents
@@ -365,6 +365,7 @@ class vector {
  */
   void assign(size_t n, const T& value) {
     m_stdvector.assign(n, value);
+    m_buffer = m_stdvector.data();
   }
 /*!
  * \brief Assign new contents to the vector, replacing its current contents
@@ -372,6 +373,7 @@ class vector {
  */
   void assign(std::initializer_list<T> il) {
     m_stdvector.assign(il);
+    m_buffer = m_stdvector.data();
   }
 
   T& at(size_t n) {
@@ -410,7 +412,7 @@ class vector {
     return m_stdvector.front();
   }
 
-  T* data() noexcept { return &front(); }
+  T* data() noexcept { return m_stdvector.data(); }
   const T* data() const noexcept { return m_stdvector.data(); }
 
   size_t max_size() const noexcept {
@@ -820,7 +822,7 @@ class array {
     return m_buffer[0];
   }
 
-  T* data() noexcept { return &front(); }
+  T* data() noexcept { return m_buffer; }
   const T* data() const noexcept { return m_buffer; }
 
   size_t max_size() const noexcept {

--- a/src/molpro/memory.h
+++ b/src/molpro/memory.h
@@ -193,9 +193,11 @@ class allocator_ : public A {
 #ifdef MOLPRO_MEMORY_FORTRAN
     memory_release((char*) p, 0);
 #else
-    _private_memory_used -= _private_memory_lengths[reinterpret_cast<char*>(p)];
-//    std::cout << "decrementing used to " << _private_memory_used << std::endl;
-    _private_memory_lengths.erase(reinterpret_cast<char*>(p));
+    auto it = _private_memory_lengths.find(reinterpret_cast<char*>(p));
+    if (it != _private_memory_lengths.end()) {
+      _private_memory_used -= it->second;
+      _private_memory_lengths.erase(it);
+    }
 #ifdef MEMORY_MALLOC
     free(reinterpret_cast<char*>(p));
 #else
@@ -255,7 +257,7 @@ using stdvector = std::vector<T, A>;
  * \code
  * #include "memory.h"
  * int main() {
- * molpro::memory_initialize(40); // bytes
+ * memory_initialize(40); // bytes
  * {
  *   molpro::vector<> arr(5);
  *   for (size_t i=0; i<arr.size(); i++) arr[i]=100*i;
@@ -445,11 +447,11 @@ class vector {
     using difference_type = std::ptrdiff_t;
     using pointer = T*;
     using reference = T&;
-    MyIterator() noexcept : pointer_holder<T>(nullptr) {}
-    MyIterator(pointer ptr) : pointer_holder<T>(ptr) {}
+    MyIterator() noexcept : pointer_holder<T,_Alloc>(nullptr) {}
+    MyIterator(pointer ptr) : pointer_holder<T,_Alloc>(ptr) {}
     MyIterator(const MyIterator&) = default;
     template<bool IsConst_ = IsConst, class = std::enable_if_t<IsConst_>>
-    MyIterator(const MyIterator<false>& rhs) : pointer_holder<T>(rhs.m_ptr) {}
+    MyIterator(const MyIterator<false>& rhs) : pointer_holder<T,_Alloc>(rhs.m_ptr) {}
 
     reference operator*() const noexcept { return *(this->m_ptr); }
     pointer operator->() const noexcept { return (this->m_ptr); }

--- a/src/molpro/mpi.h
+++ b/src/molpro/mpi.h
@@ -9,8 +9,8 @@
 #endif
 #if defined __has_include
 #if __has_include(<mpi.h>)
-#endif
 #define HAVE_MPI_H
+#endif
 #endif
 #endif
 

--- a/src/molpro/mpi.h
+++ b/src/molpro/mpi.h
@@ -85,7 +85,7 @@ inline MPI_Comm comm_global() {
   int flag;
   MPI_Initialized(&flag);
   if (!flag) {
-    MPI_Init(0, nullptr);
+    MPI_Init(nullptr, nullptr);
     return MPI_COMM_WORLD;
   }
 #else
@@ -138,7 +138,10 @@ inline int rank_global() {
  */
 inline int init() {
 #ifdef HAVE_MPI_H
-  return MPI_Init(0, nullptr);
+  int flag;
+  MPI_Initialized(&flag);
+  if (flag) return MPI_SUCCESS;
+  return MPI_Init(nullptr, nullptr);
 #else
   return 0;
 #endif

--- a/src/molpro/mpi.h
+++ b/src/molpro/mpi.h
@@ -19,6 +19,7 @@
 #else
 /// \cond DO_NOT_DOCUMENT
 #define MPI_Comm_c2f(x) x
+#define MPI_Comm_f2c(x) x
 using MPI_Comm = int64_t;
 #define MPI_COMM_NULL 0
 #define MPI_WIN_NULL 0

--- a/test/test-eigen.cpp
+++ b/test/test-eigen.cpp
@@ -29,8 +29,8 @@ TEST(LibraryManager, eigen) {
   std::vector<double> mb(n * n, 1);
   std::vector<double> mc(n * n, 0);
   Eigen::Map<Eigen::MatrixXd> mma(ma.data(), n, n);
-  Eigen::Map<Eigen::MatrixXd> mmb(ma.data(), n, n);
-  Eigen::Map<Eigen::MatrixXd> mmc(ma.data(), n, n);
+  Eigen::Map<Eigen::MatrixXd> mmb(mb.data(), n, n);
+  Eigen::Map<Eigen::MatrixXd> mmc(mc.data(), n, n);
   auto start = std::chrono::system_clock::now();
   for (size_t rep = 0; rep < repeat; ++rep)
     //    cblas_dgemm(CblasColMajor, CblasNoTrans, CblasNoTrans, n, n, n, 1,

--- a/test/test-lapacke.cpp
+++ b/test/test-lapacke.cpp
@@ -3,16 +3,15 @@
 //#include <molpro/cblas.h>
 #include <gmock/gmock.h>
 #include <molpro/lapacke.h>
+#ifndef HAVE_LAPACKE
+#error "Missing lapacke support"
+#endif
 #include <vector>
 #include <chrono>
 
 //using ::testing::HasSubstr;
 
-lapack_int thing;
 TEST(utilities, lapacke) {
-#ifndef HAVE_LAPACKE
-#error "Missing lapacke support"
-#endif
   //  std::cout << "Test Lapack with BLAS/LAPACK library " << BLA_VENDOR << std::endl;
   double a[5][3] = {{1, 1, 1}, {2, 3, 4}, {3, 5, 2}, {4, 2, 5}, {5, 4, 3}};
   double b[5][2] = {{-10, -3}, {12, 14}, {14, 12}, {16, 16}, {18, 16}};

--- a/test/test-memory.cpp
+++ b/test/test-memory.cpp
@@ -14,7 +14,7 @@ struct thing {
 };
 
 TEST(utilities_memory, construct_chars) {
-#ifdef MEMORY_FORTRAN
+#ifdef MOLPRO_MEMORY_FORTRAN
   std::vector<char> q(400000000);
   memory_initialize(q.data(), q.size());
 #endif

--- a/test/test-mpi.cpp
+++ b/test/test-mpi.cpp
@@ -1,6 +1,17 @@
 #include <gtest/gtest.h>
 #include <molpro/mpi.h>
 
+class MpiEnvironment : public ::testing::Environment {
+public:
+  void TearDown() override {
+    int finalized;
+    MPI_Finalized(&finalized);
+    if (!finalized) MPI_Finalize();
+  }
+};
+
+static auto* const mpi_env = ::testing::AddGlobalTestEnvironment(new MpiEnvironment);
+
 TEST(mpi, construct) {
   EXPECT_EQ(molpro::mpi::comm_global(),MPI_COMM_WORLD);
   EXPECT_EQ(molpro::mpi::comm_self(),MPI_COMM_SELF);

--- a/test/xout.cpp
+++ b/test/xout.cpp
@@ -1,5 +1,6 @@
 #include <fstream>
-extern std::ofstream& xout;
-std::ofstream s_xout = std::ofstream("test-iostream.log");
-std::ofstream& xout = s_xout;
-void xout_close() { xout.close(); }
+#include <ostream>
+extern std::ostream& xout;
+std::ofstream s_xout("test-iostream.log");
+std::ostream& xout = s_xout;
+void xout_close() { s_xout.close(); }


### PR DESCRIPTION
## Summary

The trigger for this branch was a one-line preprocessor bug in `src/molpro/mpi.h` that caused every C++17 build without MPI installed to fail compiling against `<mpi.h>`. Fixing that led to a multi-pass audit of the rest of the headers and tests; this PR bundles the fix plus everything that pass surfaced.

21 commits, organised so each commit is independently reviewable.

## Real bugs

- **`mpi.h` `__has_include` misuse** — `#endif` closed the test too early, so `HAVE_MPI_H` was always defined on any C++17 compiler regardless of whether `<mpi.h>` was findable. *Original report; everything else came from auditing around it.*
- **`molpro::vector::assign(size_t, T)` / `assign(initializer_list)`** — delegated to `std::vector::assign` but never refreshed the shadow `m_buffer`. Reproducer: `v.assign(size_t{8}, 42)` segfaulted on iteration. Also rewrote `assign(InputIterator, InputIterator)` to forward to `std::vector::assign` (gets the SFINAE-correct dispatch and handles input-only iterators).
- **`molpro::vector::swap` and `molpro::array::swap`** — member \`swap(*this, x)\` was found by class-scope lookup as the same 1-arg member, so any instantiation failed to compile. The free \`friend swap\` for `vector` swapped `m_stdvector` but left `m_buffer` stale.
- **`molpro::array(InputIterator, InputIterator)`** — allocated the buffer but never copied the source range.
- **`molpro::vector::emplace`** — missing return value, and passed a molpro iterator straight into `std::vector::emplace` which wants its own iterator type.
- **`molpro::array::operator[]` assert** — used `n <= m_length`, permitting one-past-the-end indexing.
- **`vector::data()` / `array::data()` (non-const)** — returned `&front()`, which is UB on empty containers. Now returns the buffer pointer directly.
- **`test/test-eigen.cpp`** — three `Eigen::Map`s all aliased `ma.data()`, so the timed `mmc = mma * mmb` reduced to a self-multiply.
- **`cblas.h` MKL detection** — `__has_include` tested `<mkl_lapacke.h>` but the included header was `<mkl_cblas.h>`; corrected to test the header we actually include.

## Latent issues (bugs not yet triggered in production)

- **`bytestream::put_metadata` on big-endian hosts** — asserted then silently returned; in `NDEBUG` builds this produced malformed streams. Now throws.
- **`molpro::mpi::init`** — re-entered `MPI_Init` if `comm_global` had already initialised MPI; now checks `MPI_Initialized` first.
- **`mpi.h` no-MPI build with `HAVE_PPIDD_H`** — the fallback block defined `MPI_Comm_c2f` but not `MPI_Comm_f2c`, which the unreachable PPIDD code path referenced; added the stub.
- **`MyIterator` base-class initialisers** — `pointer_holder<T>(...)` instead of `pointer_holder<T,_Alloc>(...)`; compiled by accident on the default allocator only.
- **`allocator_::deallocate`** — used `unordered_map::operator[]`, inserting a stray default entry for untracked pointers. Switched to `find()+erase`.
- **`bytestream(const char*)`** — read the on-wire size as `int64_t` before assigning to `size_t`; widened to `uint64_t`.

## Test and packaging hygiene

- `test-mpi` now finalises MPI in a gtest `Environment::TearDown`.
- `test-lapacke` moved its `HAVE_LAPACKE` `#error` from inside the TEST body to file scope, so the diagnostic actually fires before `lapack_int thing;` does.
- `test-memory` corrected `MEMORY_FORTRAN` to `MOLPRO_MEMORY_FORTRAN`.
- `test/xout.cpp` declaration type now matches the `extern std::ostream&` in `iostream.h` (was an `std::ofstream&` reference — ODR-fragile).
- `README.md` referenced `molpro::stderr`; the header exports `molpro::cerr`.

## Cleanups

- Public C++ standard raised from 14 to 17 (tests already required 17; recent commits made the code C++20/23-compliant).
- Removed duplicate `bytestream::position()` overload.
- Removed dead `operator+`/`operator-` templates whose iterator arguments were in non-deduced contexts.
- `allocator_::operator==`/`!=` made `const`.
- Deduplicated includes and sorted them in `memory.h`.
- Two `-Wshadow` warnings (`array(...)` parameters named `array`, `bytestream` param named `buffer`).
- Doxygen example used `molpro::memory_initialize`; the function lives at global scope.

## Deliberately not fixed

- `Options.cpp` MOLPRO double-parameter sentinel — needs the `get_inpf_c` API contract to fix safely.
- `array::front`/`back` on empty arrays — UB but matches `std::vector` semantics; fixing would change behaviour.
- `vector(size_t)` is implicit — changing it would break callers that rely on the implicit conversion.
- Static-initialisation ordering of `_private_memory_*` globals — requires refactoring to function-local statics; latent, never observed in practice.
- A handful of unused-parameter warnings on documented-but-unimplemented features (`memory_used(maximum)`, `memory_reset_maximum_stack`).

These are tracked in a follow-up issue.

## Test plan

- [x] CMake configure + build with GCC 16.1, MPI off, no MKL: succeeds.
- [x] All 10 buildable tests pass under `ctest`: `iostream.redirect`, `options.construct`, `Options.construct_from_args`, four `utilities_memory.*` sub-tests, and the three suite-level wrappers.
- [x] No `-Wshadow` warnings in library sources.
- [x] Standalone smoke tests for the bugs that don't have gtest coverage (swap, assign reallocation, bytestream roundtrip) pass.
- [x] CI on this PR exercises the MPI / BLAS / LAPACKE / Eigen targets that this host couldn't link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)