### PR TITLE
test: accept Eigen3 up to 5.x in find_package version request

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,7 +32,7 @@ print_target_properties(BLAS::BLAS)
 print_target_properties(LAPACK::LAPACK)
 
 
-find_package(Eigen3 3.3 NO_MODULE)
+find_package(Eigen3 3.3...<6 NO_MODULE)
 if (TARGET Eigen3::Eigen)
     print_target_properties(Eigen3::Eigen)
     add_executable(test-eigen test-eigen.cpp)


### PR DESCRIPTION
## Summary
- `find_package(Eigen3 3.3 NO_MODULE)` interprets `3.3` as a single component, so Eigen's ConfigVersion.cmake matches only `>=3.3 and <4`. With Eigen 5.x now common (e.g. Fedora 44 ships 5.0.1), the package is silently not found and `test-eigen` is skipped.
- Widen to `3.3...<6` (CMake 3.19+) so Eigen 3.3+, 4.x, and 5.x all satisfy.
- No source changes needed: Eigen 5 still ships the `Eigen3::Eigen` target under the `Eigen3` package name, and the APIs used in `test-eigen.cpp` (`Eigen::Map`, `.dot()`, `operator*`) are unchanged.

## Test plan
- [x] Reconfigure with Eigen 5.0.1 installed: `Eigen3::Eigen` now found.
- [x] `cmake --build . --target test-eigen` succeeds.
- [x] `ctest -R eigen` — both `LibraryManager.eigen` and `test-eigen` pass.
- [x] Full suite (excluding env-dependent `test-blas` / `test-lapacke`): 12/12 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)