### PR TITLE
audit 24

### DIFF
--- a/.github/workflows/doxygen-gh-pages.yml
+++ b/.github/workflows/doxygen-gh-pages.yml
@@ -29,8 +29,8 @@ jobs:
           rsync -av ${{github.workspace}}/build/docs/${{ github.event.repository.name }}/html .
           mkdir -p html/DoxygenTagFiles
           find ${{github.workspace}}/build/docs -name '*.tag' -exec cp {} html/DoxygenTagFiles \;
-          find ${{github.workspace}}/build/docs -name 'iostream*.html' -exec cat {} \;
-          ls -ltRa html
+#          find ${{github.workspace}}/build/docs -name 'iostream*.html' -exec cat {} \;
+#          ls -ltRa html
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3.8.0

--- a/src/molpro/bytestreamC.cpp
+++ b/src/molpro/bytestreamC.cpp
@@ -23,9 +23,6 @@ bytestream::bytestream(const char* src) {
   reset();
 }
 
-bytestream::~bytestream() {
-}
-
 molpro::array<double> bytestream::doubles() {
   bytestream::metadata md = get_metadata();
 //  uint64_t mdd[2]; memcpy(&mdd,&md,16); printf("metadata: %16X %16X\n",mdd[0],mdd[1]);

--- a/src/molpro/bytestreamC.h
+++ b/src/molpro/bytestreamC.h
@@ -29,7 +29,6 @@ class bytestream {
    * \param buffer The data obtained from a previous construction of a bytestream.
    */
   bytestream(const char* buffer);
-  ~bytestream();
   /*!
    * \brief Interpret the next array in the object as an array of doubles,
    * advance the pointer to the following object, and return the array.

--- a/src/molpro/memory.h
+++ b/src/molpro/memory.h
@@ -97,13 +97,17 @@ extern size_t _private_memory_used;
 extern size_t _private_memory_maximum_allocatable;
 extern std::unordered_map<char*, size_t> _private_memory_lengths;
 
+/*!
+ * \brief Initialize the memory system
+ * \param buffer is ignored. Present for compatibility with the enhanced interface in the Molpro environment
+ * \param max The number of bytes to be reserved for the stack
+ */
 inline size_t memory_initialize(char *buffer, size_t max) {
   return (_private_memory_maximum_allocatable = max);
 } // more checks
 /*!
- * \brief memory_used Report used memory
- * \param maximum if true (default is false), report the maximum
- * memory allocated to date, in bytes.
+ * \brief memory_used Report currently used memory
+ * \param maximum is ignored. Present for compatibility with the enhanced interface in the Molpro environment
  * \return
  */
 inline size_t memory_used(int maximum = 0) { return _private_memory_used; }
@@ -120,10 +124,7 @@ inline void memory_print_status() {
   std::cout << "Memory remaining: " << memory_remaining() << std::endl;
 }
 /*!
- * \brief memory_reset_maximum_stack  Reset the maximum stack used
- * statistic to the currently-used stack
- * \param level if non-negative, the stack position desired; default is
- * current stack size in bytes
+ * \brief memory_reset_maximum_stack is a no-op. Present for compatibility with the enhanced interface in the Molpro environment
  */
 inline void memory_reset_maximum_stack(int64_t level) {
 

--- a/src/molpro/memory.h
+++ b/src/molpro/memory.h
@@ -805,10 +805,12 @@ class array {
   }
 
   T& back() noexcept {
+    if (empty()) throw std::out_of_range("array::back() called on empty array");
     return m_buffer[size() - 1];
   }
 
   const T& back() const noexcept {
+    if (empty()) throw std::out_of_range("array::back() called on empty array");
     return m_buffer[size() - 1];
   }
 
@@ -817,10 +819,12 @@ class array {
   }
 
   T& front() noexcept {
+    if (empty()) throw std::out_of_range("array::front() called on empty array");
     return m_buffer[0];
   }
 
   const T& front() const noexcept {
+    if (empty()) throw std::out_of_range("array::front() called on empty array");
     return m_buffer[0];
   }
 

--- a/src/molpro/memory.h
+++ b/src/molpro/memory.h
@@ -290,7 +290,7 @@ class vector {
    * \brief Construct a vector of type T with managed storage.
    * \param length The number of elements of buffer.
    */
-  vector(size_t const length = 0)
+explicit vector(size_t const length = 0)
       : m_stdvector(length), m_buffer(m_stdvector.data()) {}
 
 /*!


### PR DESCRIPTION
- **explicit molpro::vector constructor**
- **Throw exception in array::front and array::back if array is empty.**
- **Improve documentation of memory interface in non-Molpro mode**
- **bytestream default destructor removed**
- **ci**
