### PR TITLE
Options.cpp: document why MOLPRO double branch ignores def

### DIFF
--- a/src/molpro/Options.cpp
+++ b/src/molpro/Options.cpp
@@ -66,6 +66,8 @@ int Options::parameter(const std::string &key, int def) const {
 
 double Options::parameter(const std::string &key, double def) const {
 #ifdef MOLPRO
+  // Molpro's get_inpf_c aborts on a missing key rather than returning a sentinel,
+  // so `def` is intentionally unused in this branch (cf. int / string siblings).
   double r = get_inpf_c(upcase(key).c_str(), upcase(m_program).c_str());
   return r;
 #endif


### PR DESCRIPTION
## Summary
Resolves the first bullet of #25. Per @pjknowles, `get_inpf_c` aborts on a missing key rather than returning a sentinel, so the `def` argument of `Options::parameter(key, double)` is intentionally unused in the MOLPRO branch — the apparent asymmetry with the `int` / `std::string` siblings (which do use `def`) is by design. Add a two-line comment so a future audit doesn't flag it again.

## Test plan
- [x] Comment-only change in the `#ifdef MOLPRO` branch; no behavioural difference. Non-MOLPRO build path is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)